### PR TITLE
task_usecase作った

### DIFF
--- a/usecase/task_usecase.go
+++ b/usecase/task_usecase.go
@@ -17,7 +17,7 @@ type taskUsecase struct {
 	tr repository.ITaskRepository
 }
 
-func NewTaskUsecase(tr repository.ITaskRepository) {
+func NewTaskUsecase(tr repository.ITaskRepository) ITaskUsecase {
 	return &taskUsecase{tr}
 }
 

--- a/usecase/task_usecase.go
+++ b/usecase/task_usecase.go
@@ -1,0 +1,88 @@
+package usecase
+
+import (
+	"github.com/todo_test/model"
+	"github.com/todo_test/repository"
+)
+
+type ITaskUsecase interface {
+	GetAllTasks(userId uint) ([]model.TaskRespons, error)
+	GetTaskById(userId uint, taskId uint) (model.TaskRespons, error)
+	CreateTask(task model.Task) (model.TaskRespons, error)
+	UpdateTask(task model.Task, userId uint, taskId uint) (model.TaskRespons, error)
+	DeleteTask(userId uint, taskId uint) error
+}
+
+type taskUsecase struct {
+	tr repository.ITaskRepository
+}
+
+func NewTaskUsecase(tr repository.ITaskRepository) {
+	return &taskUsecase{tr}
+}
+
+func (tu *taskUsecase) GetAllTasks(userId uint) ([]model.TaskRespons, error) {
+	tasks := []model.Task{}
+	if err := tu.tr.GetAllTasks(&tasks, userId); err != nil {
+		return nil, err
+	}
+	resTasks := []model.TaskRespons{}
+	for _, v := range tasks {
+		t := model.TaskRespons{
+			ID:        v.ID,
+			Title:     v.Title,
+			CreatedAt: v.CreatedAt,
+			UpdatedAt: v.UpdatedAt,
+		}
+		resTasks = append(resTasks, t)
+	}
+	return resTasks, nil
+}
+
+func (tu *taskUsecase) GetTaskById(userId uint, taskId uint) (model.TaskRespons, error) {
+	task := model.Task{}
+	if err := tu.tr.GetTaskById(&task, userId, taskId); err != nil {
+		return model.TaskRespons{}, err
+	}
+	resTask := model.TaskRespons{
+		ID:        task.ID,
+		Title:     task.Title,
+		CreatedAt: task.CreatedAt,
+		UpdatedAt: task.UpdatedAt,
+	}
+	return resTask, nil
+}
+
+func (tu *taskUsecase) CreateTask(task model.Task) (model.TaskRespons, error) {
+	if err := tu.tr.CreateTask(&task); err != nil {
+		return model.TaskRespons{}, nil
+	}
+	resTask := model.TaskRespons{
+		ID:        task.ID,
+		Title:     task.Title,
+		CreatedAt: task.CreatedAt,
+		UpdatedAt: task.UpdatedAt,
+	}
+	return resTask, nil
+
+}
+
+func (tu *taskUsecase) UpdateTask(task model.Task, userId uint, taskId uint) (model.TaskRespons, error) {
+	if err := tu.tr.UpdateTask(&task, userId, taskId); err != nil {
+		return model.TaskRespons{}, err
+	}
+	resTask := model.TaskRespons{
+		ID:        taskId,
+		Title:     task.Title,
+		CreatedAt: task.CreatedAt,
+		UpdatedAt: task.UpdatedAt,
+	}
+	return resTask, nil
+}
+
+func (tu *taskUsecase) DeleteTask(userId uint, taskId uint) error {
+	if err := tu.tr.DeleteTask(userId, taskId); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## 学び
### クリーンアキテクチャーの基本
- interface
- struct
- constructor
の順番で作って、ファイル下か別ファイルに関数の実装を作成する。
この時repository層とusecase層で若干コードを書く感じが違うのでそこに注意すること

### repository層とusecase層の書く感じの違い
repositoryはほぼほぼCRUD処理を書くところで、GormやXormなどのORMのCRUD操作向けの関数を呼んで取得した値を返却したり、デリートしたりする層である。
なので
``` go
type Irepo interface {
    GetAll (hoges *[]model.hoge ) error
    Create (hoge *model.hoge,) error
    Update (hoge *model.hoge, hogeId uint) error
    Delete (hogeId uint) error
}

type repo struct {
    repo *gorm.DB
}

func NewRepo (db *gorm.DBとか) Irepo {
    return &repo{db}
}
```
のようなDBに対する基本的な処理構成を書く

usecase層は上記のrepository層に依存して（依存性注入）repository層の処理を呼びながら、適切なレスポンスを作成してフロント側に返却するように書く
``` go
type Iuc interface {
    GetAll (hoges *[]model.hoge) (res []response , error) //返り値にレスポンスが増える
    Create (hoge *model.hoge) (res response , error)
    Update (hoge *model.hoge, hogeId uint) (res response , error)
    Delete (hogeId uint) error
}

type uc struct {
    // 依存性注入
    repo Irepo
}

func NewUc (repo Irepo) Iuc {
    return &uc{repo:repo}
}

// レスポンスを返すための処理を書く
...
```
こんな感じで
- interfaceはrepositoryのものを下敷きに返り値にレスポンスを追加
- structはrepositoryのためのフィールドをrepositoryのインターフェイス型で作成して依存させる
- constructorはrepositoryの型の変数を引数にとってusecaseインスタンスを生成してそのアドレスを返す
というような感じで作っていく

### つい混乱する書き方
go言語では、基本的に関数に対してインスタンスのポインタを引数として渡すことが多い。
この場合
``` go
func hogeFunc (hoge model.Hoge, args...) (respons , error) {
    // インスタンスを引数に取るrepositoryの処理がきちんと動いたかの確認
    if err := uc.repo.func(&hoge, args...); err != nil{ error処理 }
    
    // 本チャンの処理
    ...
}
```
のような書き方が一般的であるが、この時
``` go
if err := uc.repo.func(&hoge, args...); err != nil{ error処理 }
```
の行のように参照渡しの関数を呼ぶと、関数を呼んだ時点で渡したインスタンスの値は変化する。
そのため、errには処理成功のnilかerrorしか値が返ってこない（し、そうなるようなrepositoryの関数実装になる）
つまりjsのように関数を呼んでも、必ず入力した値にちなんだ返却値が返ってくるということはない。

あくまでインスタンスを渡して、インスタンスに正しく処理が走ったかどうかの成功失敗の結果だけが返ってくる。
変化してしまったインスタンスの値を改めて参照し、レスポンスとしてフロント側に返す処理が別途必要になる。

これはおそらくDBを操作する関数によって値を拾ってくる処理と、それを適切な返却値（jsonなど）に加工して渡す処理を分けるためのものである。